### PR TITLE
[java] disallow build failure on 12, 13 & 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,4 @@ install:
 matrix:
   fast_finish: true
   allow_failures:
-    - jdk: openjdk12
-    - jdk: openjdk13
-    - jdk: openjdk14
     - jdk: openjdk-ea


### PR DESCRIPTION
now that mockito is updated builds pass on these versions
-> failures were down to jpms+mocks bytecode generation