### PR TITLE
[travis] allow failures on 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,7 @@ install:
 matrix:
   fast_finish: true
   allow_failures:
+# openjdk11 from install-jdk is 11.0.2 and not the latest
+    - jdk: openjdk11
     - jdk: openjdk15
     - jdk: openjdk-ea


### PR DESCRIPTION
11 is having issues connecting to a maven repo, install-jdk uses
11.0.2 and not the latest release (which might fix the issue)

For now just 14 is good enough