### PR TITLE
[stub-idp] disable fs watching tests that fail on mac

### DIFF
--- a/stub-idp/src/test/java/stubidp/stubidp/listeners/StubIdpsFileListenerTest.java
+++ b/stub-idp/src/test/java/stubidp/stubidp/listeners/StubIdpsFileListenerTest.java
@@ -8,6 +8,8 @@ import io.dropwizard.configuration.DefaultConfigurationFactoryFactory;
 import io.dropwizard.jackson.Jackson;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import stubidp.saml.stubidp.configuration.SamlConfigurationImpl;
 import stubidp.stubidp.configuration.IdpStubsConfiguration;
 import stubidp.stubidp.configuration.StubIdp;
@@ -35,6 +37,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+// "work around" https://bugs.openjdk.java.net/browse/JDK-7133447
+@DisabledOnOs(OS.MAC)
 public class StubIdpsFileListenerTest {
 
     private final File YML_FILE;


### PR DESCRIPTION
Adds a "work around" for https://bugs.openjdk.java.net/browse/JDK-7133447

Alternative would be to put in a long delay, which would also be flaky.
CI is run on Linux with all the tests, so on that basis rely on the
underlying macOS jvm implementation working correctly.